### PR TITLE
Fix bug related to saveConfig scope type (issue 19)

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -5,6 +5,7 @@
  */
 namespace Bitpay\Core\Helper;
 
+use Magento\Framework\App\Config\ScopeConfigInterface;
 
 class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {
@@ -230,7 +231,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             throw new \Exception('In \Bitpay\Core\Helper\Data::sendPairingRequest(): could not create new Mage_Core_Model_Config object. Cannot continue!');
         }
 
-        if($config->saveConfig('payment/bitpay/token', $token->getToken(), $store->getStore()->getCode(), 0)) {
+        if($config->saveConfig('payment/bitpay/token', $token->getToken(), ScopeConfigInterface::SCOPE_TYPE_DEFAULT, 0)) {
             $this->debugData('[INFO] In \Bitpay\Core\Helper\Data::sendPairingRequest(): token saved to database.');
         } else {
             $this->debugData('[ERROR] In \Bitpay\Core\Helper\Data::sendPairingRequest(): token could not be saved to database.');

--- a/Model/MagentoStorage.php
+++ b/Model/MagentoStorage.php
@@ -1,6 +1,8 @@
 <?php
 namespace Bitpay\Core\Model;
 
+use Magento\Framework\App\Config\ScopeConfigInterface;
+
 class MagentoStorage implements \Bitpay\Storage\StorageInterface {
 	/**
 	 * @var array
@@ -17,13 +19,12 @@ class MagentoStorage implements \Bitpay\Storage\StorageInterface {
 
 		$encryptedData = \Magento\Framework\App\ObjectManager::getInstance() -> get('\Magento\Framework\Encryption\EncryptorInterface') -> encrypt($data);
 		$config = \Magento\Framework\App\ObjectManager::getInstance() -> get('\Magento\Config\Model\ResourceModel\Config');
-		$store = \Magento\Framework\App\ObjectManager::getInstance() -> get('\Magento\Store\Model\StoreManagerInterface');
 		$helper = \Magento\Framework\App\ObjectManager::getInstance() -> get('\Bitpay\Core\Helper\Data');
 
 		if (true === isset($config) && false === empty($config)) {
-			$config -> saveConfig($key -> getId(), $encryptedData, $store -> getStore() -> getCode(), 0);
+			$config->saveConfig($key -> getId(), $encryptedData, ScopeConfigInterface::SCOPE_TYPE_DEFAULT, 0);
 		} else {
-			$helper -> debugData('[ERROR] In file lib/Bitpay/Storage/MagentoStorage.php, class MagentoStorage::persist - Could not instantiate a \Mage_Core_Model_Config object.');
+			$helper->debugData('[ERROR] In file lib/Bitpay/Storage/MagentoStorage.php, class MagentoStorage::persist - Could not instantiate a \Mage_Core_Model_Config object.');
 			throw new \Exception('[ERROR] In file lib/Bitpay/Storage/MagentoStorage.php, class MagentoStorage::persist - Could not instantiate a \Mage_Core_Model_Config object.');
 		}
 	}


### PR DESCRIPTION
Config's Resouremodel's saveconfig function was called with an incorrect scope type leading to an application crash after saving the value to the core config database.

/Model/MagentoStorage.php and /Helper/Data.php now have the scope config set to SCOPE_TYPE_DEFAULT when they call saveConfig.

The goal of the previous code is unclear to me as the storemanager was called to request the current store, which is independent of the chosen scope in the admin for setting configuration values.