### PR TITLE
Set the composer dependency of bitpay/php-client to a version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require": {
         "composer/installers": "~1.0",
-        "bitpay/php-client": "dev-master#9027ce67e4b28516ff1ebd1046bdd15c37a7a59f"
+        "bitpay/php-client": "2.2.4"
     },
     "require-dev": {
         "symfony/finder": "~2.3",


### PR DESCRIPTION
In order to improve the stability-requirements of packages that depend on this package, the dependency on bitpay/php-client was changed to the first following version after the old specified commit.

Perhaps the maintainer of this package can raise the version further.